### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The following library are used in blocktest:
 ## 4.2. Prerequisite Linux
 
 ```bash
-sudo apt-get install -y cmake libboost1.65-all-dev qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5opengl5-dev libqcustomplot-dev
+sudo apt-get install -y cmake libboost-all-dev qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5opengl5-dev libqcustomplot-dev
 ```
 
 ### 4.2.1. Numpy


### PR DESCRIPTION
libboost1.65-all-dev modified to libboost-all-dev due to failing install of package

cc @triccyx @Nicogene