### PR TITLE
Add the possibility to launch blocktestrunner and Scriptbuilder from any dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Suggested location:
 ```
 ~\blocktest\build
 ```
+It is possible also to run `blocktestrunner` and `Scriptbuilder` from any folder, you have just to define `BLOCKTEST_RESOURCE_PATH` where all the plugins, xmltemplate, and test folder
+are stored.
+
+If you are using the [`robotology-superbuild`](https://github.com/robotology/robotology-superbuild) with the `ROBOT_TESTING` profile enabled, the variable is already exported by the superbuild setup scripts.
 # 6. Test writing
 
 For easy test writing, you can skip directly to the section [Scriptbuilder](##5.6.-test-writing-with-scriptbuilder). You can use the test writing tool called ScriptBuilder.  <br>

--- a/src/blocktestcore/general.h
+++ b/src/blocktestcore/general.h
@@ -45,20 +45,27 @@ constexpr char path_delimiter =
 inline std::string calcolateTestName(const std::string& name,const std::string& path)
 {
     std::string out{maintestfile};
+
+    if (!name.empty())
+    {
+        out = name;
+    }
+
     if (path.empty()) // no specific path specified, looking in the default ones
     {
         std::vector<std::string> resourcePaths;
         char* pathCStr = getenv("BLOCKTEST_RESOURCE_PATH");
         if (pathCStr && *pathCStr != '\0')
         {
-            boost::split(resourcePaths, std::string{pathCStr}, boost::is_any_of(std::string{ path_delimiter }));
+            std::string pathStr{ pathCStr };
+            boost::split(resourcePaths, pathStr, boost::is_any_of(std::string{ path_delimiter }));
         }
 
         if (! boost::filesystem::exists(out) )
         {
             for (const auto& path : resourcePaths)
             {
-                std::string fullpath = path + std::string{ boost::filesystem::path::preferred_separator } + "test/test.xml";
+                std::string fullpath = path + std::string{ boost::filesystem::path::preferred_separator } + out;
                 if (boost::filesystem::exists(fullpath))
                 {
                     out = fullpath;
@@ -67,14 +74,10 @@ inline std::string calcolateTestName(const std::string& name,const std::string& 
             }
         }
     }
-
-    if(!name.empty())
+    else
     {
-        out=name;
+        out = path + std::string{ boost::filesystem::path::preferred_separator } + out;
     }
-
-    if(!path.empty())
-        out=path+"/"+out;
 
     return out;
 }

--- a/src/blocktestcore/general.h
+++ b/src/blocktestcore/general.h
@@ -45,6 +45,29 @@ constexpr char path_delimiter =
 inline std::string calcolateTestName(const std::string& name,const std::string& path)
 {
     std::string out{maintestfile};
+    if (path.empty()) // no specific path specified, looking in the default ones
+    {
+        std::vector<std::string> resourcePaths;
+        char* pathCStr = getenv("BLOCKTEST_RESOURCE_PATH");
+        if (pathCStr && *pathCStr != '\0')
+        {
+            boost::split(resourcePaths, std::string{pathCStr}, boost::is_any_of(std::string{ path_delimiter }));
+        }
+
+        if (! boost::filesystem::exists(out) )
+        {
+            for (const auto& path : resourcePaths)
+            {
+                std::string fullpath = path + std::string{ boost::filesystem::path::preferred_separator } + "test/test.xml";
+                if (boost::filesystem::exists(fullpath))
+                {
+                    out = fullpath;
+                    return out;
+                }
+            }
+        }
+    }
+
     if(!name.empty())
     {
         out=name;

--- a/src/scriptbuilder/actiontreemodel.cpp
+++ b/src/scriptbuilder/actiontreemodel.cpp
@@ -31,6 +31,7 @@ void ActionTreeModel::LoadXml()
     QStandardItem *item = invisibleRootItem();
     //std::string path = ;
     fs::path path("./xmltemplate");
+    bool found{false};
 
     if(!fs::exists(path))
     {
@@ -43,13 +44,16 @@ void ActionTreeModel::LoadXml()
             if (fs::exists(str))
             {
                 path = str;
+                found = true;
                 break;
             }
         }
-        QMessageBox messageBox;
-        messageBox.critical(nullptr,"ERROR","Missing the actions templates folder 'xmltemplate.xml'. Some functionalities will not be active.");
-        messageBox.setFixedSize(800,400);
-        return;
+        if (!found) {
+            QMessageBox messageBox;
+            messageBox.critical(nullptr,"ERROR","Missing the actions templates folder 'xmltemplate.xml'. Some functionalities will not be active.");
+            messageBox.setFixedSize(800,400);
+            return;
+        }
     }
 
     for (const fs::directory_entry & folder : fs::directory_iterator(path))

--- a/src/scriptbuilder/librarymodel.cpp
+++ b/src/scriptbuilder/librarymodel.cpp
@@ -13,10 +13,12 @@
 
 #include "librarymodel.h"
 #include <boost/filesystem.hpp>
+#include <iostream>
+#include <sstream>
 
 namespace fs = boost::filesystem;
 
-LibraryModel::LibraryModel()
+LibraryModel::LibraryModel(const std::vector<std::string>& resourcePaths) : resourcePaths_(resourcePaths)
 {
     bool ok=QObject::connect(this,&QStandardItemModel::itemChanged, this, &LibraryModel::onChanged);
     Q_ASSERT(ok);
@@ -48,6 +50,21 @@ void LibraryModel::redraw()
         if(!fs::exists(path+".so"))
         {
             missingFile=true;
+            std::stringstream ss;
+            for (const auto& p : resourcePaths_)
+            {
+               ss.str("");
+               ss.clear();
+               ss << p << std::string{ boost::filesystem::path::preferred_separator } << path << ".so";
+               auto str = ss.str();
+               if (fs::exists(str))
+               {
+                   path = str;
+                   missingFile=false;
+                   break;
+               }
+            }
+
         }
 
         QStandardItem* pathItem = new QStandardItem(path.c_str());

--- a/src/scriptbuilder/librarymodel.h
+++ b/src/scriptbuilder/librarymodel.h
@@ -23,7 +23,7 @@ class LibraryModel : public QStandardItemModel
 {
     Q_OBJECT
 public:
-    LibraryModel();
+    LibraryModel(const std::vector<std::string>& resourcePaths);
     void load(const std::string& fileName);
     const pugi::xml_document& getDocument() const;
     std::list<std::string> getLibraryListEnabled() const;
@@ -37,6 +37,7 @@ public slots:
 private:
     pugi::xml_document doc_;
     std::list<std::string> libraryListEnabled_;
+    std::vector<std::string> resourcePaths_;
 
     void redraw();
 };

--- a/src/scriptbuilder/mainwindow.cpp
+++ b/src/scriptbuilder/mainwindow.cpp
@@ -43,7 +43,7 @@ MainWindow::MainWindow(QWidget *parent) :
     loggerModel_ = new LoggerModel("log/log.log");
     prerequisiteLoggerModel_=new LoggerModel("");
     prerequisiteComboModel_=new QStringListModel();
-    libraryModel_= new LibraryModel();
+    libraryModel_= new LibraryModel(resourcePaths_);
 
     ui->setupUi(this);
 
@@ -151,10 +151,11 @@ void MainWindow::tryLoadTestsFile()
 
     for (const auto& path:resourcePaths_)
     {
+        ss.str("");
         ss.clear();
         ss << path << "/test/test.xml";
         str = ss.str();
-        if (fs::exists(ss.str()))
+        if (fs::exists(str))
         {
             loadTests(str.c_str());
             return;
@@ -419,15 +420,19 @@ void MainWindow::actionExit()
 
 void MainWindow::on_startButton_clicked()
 {
+    std::string process_str{"./blocktestrunner"};
+    if ( ! boost::filesystem::exists(process_str) ) {
+        process_str = "blocktestrunner";
+    }
     try
     {
-        process_=std::make_shared<boost::process::child>("./blocktestrunner");
+        process_=std::make_shared<boost::process::child>(process_str);
         process_->detach();
     }
     catch (...)
     {
         QMessageBox messageBox;
-        messageBox.critical(nullptr,"ERROR","Missing blockTest application in current folder.");
+        messageBox.critical(nullptr,"ERROR","Missing blocktestrunner application.");
         messageBox.setFixedSize(800,400);
         return;
     }

--- a/src/scriptbuilder/prerequisitemodel.cpp
+++ b/src/scriptbuilder/prerequisitemodel.cpp
@@ -13,6 +13,7 @@
 
 #include "prerequisitemodel.h"
 #include <cassert>
+#include <iostream>
 
 PrerequisiteModel::PrerequisiteModel()
 {


### PR DESCRIPTION
In order to do that it is just needed to explicit `BLOCKTEST_RESOURCE_PATH` pointing where the `plugins`, `xmltemplate` dir and `test/test.xml` are stored.

For the case of `robotology-superbuild`, it hat to point to `${ROBOTOLOGY_INSTALL_PREFIX}/bin`.

Tested successfully both ScriptBuilder and blocktestrunner

Please review code