### PR TITLE
Remove unnecessary set of FindBoost CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,6 @@ else()
   add_subdirectory(extern/pugixml)
 endif()
 
-set(Boost_NO_BOOST_CMAKE ON)
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_USE_MULTITHREAD ON)
 set(BOOST_MIN_VERSION "1.65.0")
 
 find_package(YCM REQUIRED)


### PR DESCRIPTION
An open source project that is meant to be built with several package manager thatprovide its dependencies should not set any Boost_** related CMake variables, because (for example) if someone wants to build it with a static Boost version it should be possible to do so.

More in particular, this patch fixes compilation of blocktest when using Conda-provided Boost, as in that case the Boost provides all the necessary information in CMake-generated config files, that are not searched if `Boost_NO_BOOST_CMAKE` is set to `OFF` , see https://github.com/robotology/robotology-superbuild/pull/532#issuecomment-733283588 for more info.