### PR TITLE
Set the c++ standard to 17 after usage of filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
     endif()
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Build position independent code.
 # Position Independent Code (PIC) is commonly used for shared libraries so that


### PR DESCRIPTION
@traversaro made me aware that the usage of filesystem has been introduced in https://github.com/robotology/blocktest/commit/65ccf23b4254d41e99babe51e138917d2b1a608b#diff-4d19f6c5be5264a89fc03f09b18025f2dfcc071e8249f7361d50adc26aee3cbf then we need to enforce the usage of c++17 for using it