### PR TITLE
IWYU: Add thread include in dataLogger.h

### DIFF
--- a/src/blocktestcore/dataLogger.h
+++ b/src/blocktestcore/dataLogger.h
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <queue>
 #include <iomanip>
+#include <thread>
 
 namespace BlockTestCore
 {


### PR DESCRIPTION
The `dataLogger.h` file was using classes like `std::thread`, but the `thread` header was never included. This PR fixes this problem by adding the necessary include.

Without this fix, the compilation on Ubuntu 22.04 is failing with error:
~~~
2022-01-19T08:11:24.2185110Z /usr/bin/c++ -DBOOST_ALL_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -Dblocktestcore_EXPORTS -I/__w/robotology-superbuild/robotology-superbuild/build/src/blocktestcore/src/blocktestcore/blocktestcore_autogen/include -I/__w/robotology-superbuild/robotology-superbuild/src/blocktestcore/src/blocktestcore -I/__w/robotology-superbuild/robotology-superbuild/src/blocktestcore/extern/pugixml -Wall -Wextra -g -fPIC -std=gnu++17 -MD -MT src/blocktestcore/CMakeFiles/blocktestcore.dir/dataLogger.cpp.o -MF src/blocktestcore/CMakeFiles/blocktestcore.dir/dataLogger.cpp.o.d -o src/blocktestcore/CMakeFiles/blocktestcore.dir/dataLogger.cpp.o -c /__w/robotology-superbuild/robotology-superbuild/src/blocktestcore/src/blocktestcore/dataLogger.cpp
2022-01-19T08:11:24.2186844Z /__w/robotology-superbuild/robotology-superbuild/src/blocktestcore/src/blocktestcore/dataLogger.cpp: In member function 'void BlockTestCore::DataLogger::work()':
2022-01-19T08:11:24.2188009Z /__w/robotology-superbuild/robotology-superbuild/src/blocktestcore/src/blocktestcore/dataLogger.cpp:68:27: error: 'sleep_for' is not a member of 'std::this_thread'
2022-01-19T08:11:24.2189670Z    68 |         std::this_thread::sleep_for(std::chrono::milliseconds(sleepTimeMsec_));
2022-01-19T08:11:24.2189958Z       |                           ^~~~~~~~~
~~~

See https://github.com/robotology/robotology-superbuild/pull/998#issuecomment-1016190486 .