### PR TITLE
Update publish-docker.yml

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -42,7 +42,7 @@ jobs:
       id: add_tag_latest
       if: ${{ inputs.add_tag_latest }}
       run: |
-        echo "::set-output name=tag::, latest"
+        echo "tag=, latest" >> $GITHUB_OUTPUT
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@main
       env:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/